### PR TITLE
Dockerfile Update per Linter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM golang:alpine AS builder
 # Install git.
 # Git is required for fetching the dependencies.
-RUN apk update && apk add --no-cache git=2.26.2-r0
+RUN apk update && apk add --no-cache 'git=~2'
 
 # Install dependencies
 ENV GO111MODULE=on

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM golang:alpine AS builder
 # Install git.
 # Git is required for fetching the dependencies.
-RUN apk update && apk add --no-cache git
+RUN apk update && apk add --no-cache git=2.30.0-r0
 
 # Install dependencies
 ENV GO111MODULE=on
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /go/main .
 ############################
 # STEP 2 build a small image
 ############################
-FROM alpine
+FROM alpine:3
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM golang:alpine AS builder
 # Install git.
 # Git is required for fetching the dependencies.
-RUN apk update && apk add --no-cache git=2.30.0-r0
+RUN apk update && apk add --no-cache git=2.26.2-r0
 
 # Install dependencies
 ENV GO111MODULE=on


### PR DESCRIPTION
Dockerfile updated per linter,

For apk git package, the major version 2 is selected, so it will always pull the most up to date minor version